### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/I Am Poor/AppDelegate.swift
+++ b/I Am Poor/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
         return true


### PR DESCRIPTION
Getting the following error in XCode:

/Users/michaelmullen/coding_courses/ios12_and_swift4/I-Am-Poor-iOS12/I Am Poor/AppDelegate.swift:17:98: 'UIApplicationLaunchOptionsKey' has been renamed to 'UIApplication.LaunchOptionsKey'